### PR TITLE
Upgrade markdown to markdownv2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,10 +25,7 @@ jobs:
           go get -v -t -d ./...
 
       - name: Build telegram-rss-bot on linux/amd64
-        env:
-          GOOS: linux
-          GOARCH: amd64
-        run: go build -o build/telegram-rss-bot-$GOOS-$GOARCH
+        run: go build -v -o build/telegram-rss-bot-linux-amd64
 
       - name: Test
         run: go test -v .
@@ -55,11 +52,8 @@ jobs:
         run: |
           go get -v -t -d ./...
 
-      - name: Build telegram-rss-bot on $GOOS/$GOARCH
-        env:
-          GOOS: windows
-          GOARCH: amd64
-        run: go build -o build/telegram-rss-bot-$GOOS-$GOARCH
+      - name: Build telegram-rss-bot on windows/amd64
+        run: go build -v -o build/telegram-rss-bot-windows-amd64.exe
 
       - name: Test
         run: go test -v .
@@ -86,11 +80,8 @@ jobs:
         run: |
           go get -v -t -d ./...
 
-      - name: Build telegram-rss-bot on $GOOS/$GOARCH
-        env:
-          GOOS: darwin
-          GOARCH: amd64
-        run: go build -o build/telegram-rss-bot-$GOOS-$GOARCH
+      - name: Build telegram-rss-bot on darwin/amd64
+        run: go build -v -o build/telegram-rss-bot-darwin-amd64
 
       - name: Test
         run: go test -v .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,10 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        goos: [linux, windows, darwin]
-        goarch: [amd64]
     steps:
-
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
@@ -30,10 +27,18 @@ jobs:
         run: |
           go get -v -t -d ./...
 
+      - name: Set GOOS
+        run: |
+          echo ::set-env name=GOOS::$(go env GOOS)
+
+      - name: Set GOARCH
+        run: |
+          echo ::set-env name=GOARCH::$(go env GOARCH)
+
       - name: Build telegram-rss-bot on ${{ matrix.os }}
         env:
-          GOARCH: ${{ matrix.goarch }}
-          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ env.GOARCH }}
+          GOOS: ${{ env.GOOS }}
         run: go build -o build/telegram-rss-bot-$goos-$goarch
 
       - name: Test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,19 +27,8 @@ jobs:
         run: |
           go get -v -t -d ./...
 
-      - name: Set GOOS
-        run: |
-          echo ::set-env name=GOOS::$(go env GOOS)
-
-      - name: Set GOARCH
-        run: |
-          echo ::set-env name=GOARCH::$(go env GOARCH)
-
       - name: Build telegram-rss-bot on ${{ matrix.os }}
-        env:
-          GOARCH: ${{ env.GOARCH }}
-          GOOS: ${{ env.GOOS }}
-        run: go build -o build/telegram-rss-bot-$GOARCH-$GOARCH
+        run: go build -o build/telegram-rss-bot-$(go env GOOS)-$(go env GOARCH)
 
       - name: Test
         run: go test -v .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,35 +6,99 @@ on:
   pull_request:
     branches: [ master ]
 
+strategy:
+  matrix:
+    os: [ubuntu-latest, windows-latest, macos-latest]
+
 jobs:
   build:
-    name: Build ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    steps:
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v2
-        with:
-          go-version: ^1.13
-        id: go
+    - name: Build telegram-rss-bot on linux/amd64
+      runs-on: ubuntu-latest
+      steps:
+        - name: Set up Go 1.x
+          uses: actions/setup-go@v2
+          with:
+            go-version: ^1.13
+          id: go
 
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        - name: Check out code into the Go module directory
+          uses: actions/checkout@v2
 
-      - name: Get dependencies
-        run: |
-          go get -v -t -d ./...
+        - name: Get dependencies
+          run: |
+            go get -v -t -d ./...
 
-      - name: Build telegram-rss-bot on ${{ matrix.os }}
-        run: go build -o build/telegram-rss-bot-$(go env GOOS)-$(go env GOARCH)
+        - name: Build telegram-rss-bot on linux/amd64
+          env:
+            GOOS: linux
+            GOARCH: amd64
+          run: go build -o build/telegram-rss-bot-$GOOS-$GOARCH
 
-      - name: Test
-        run: go test -v .
+        - name: Test
+          run: go test -v .
 
-      - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          # A file, directory or wildcard pattern that describes what to upload
-          path: build/
+        - name: Upload a Build Artifact
+          uses: actions/upload-artifact@v2
+          with:
+            # A file, directory or wildcard pattern that describes what to upload
+            path: build/
+    - name: Build telegram-rss-bot on windows/amd64
+      runs-on: windows-latest
+      steps:
+        - name: Set up Go 1.x
+          uses: actions/setup-go@v2
+          with:
+            go-version: ^1.13
+          id: go
+
+        - name: Check out code into the Go module directory
+          uses: actions/checkout@v2
+
+        - name: Get dependencies
+          run: |
+            go get -v -t -d ./...
+
+        - name: Build telegram-rss-bot on $GOOS/$GOARCH
+          env:
+            GOOS: windows
+            GOARCH: amd64
+          run: go build -o build/telegram-rss-bot-$GOOS-$GOARCH
+
+        - name: Test
+          run: go test -v .
+
+        - name: Upload a Build Artifact
+          uses: actions/upload-artifact@v2
+          with:
+            # A file, directory or wildcard pattern that describes what to upload
+            path: build/
+    - name: Build telegram-rss-bot on darwin/amd64
+      runs-on: macos-latest
+      steps:
+        - name: Set up Go 1.x
+          uses: actions/setup-go@v2
+          with:
+            go-version: ^1.13
+          id: go
+
+        - name: Check out code into the Go module directory
+          uses: actions/checkout@v2
+
+        - name: Get dependencies
+          run: |
+            go get -v -t -d ./...
+
+        - name: Build telegram-rss-bot on $GOOS/$GOARCH
+          env:
+            GOOS: darwin
+            GOARCH: amd64
+          run: go build -o build/telegram-rss-bot-$GOOS-$GOARCH
+
+        - name: Test
+          run: go test -v .
+
+        - name: Upload a Build Artifact
+          uses: actions/upload-artifact@v2
+          with:
+            # A file, directory or wildcard pattern that describes what to upload
+            path: build/

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,43 @@
+name: Build telegram-rss-bot
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.13
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
+          if [ -f Gopkg.toml ]; then
+              curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+              dep ensure
+          fi
+
+      - name: Build
+        run: make all
+
+      - name: Test
+        run: go test -v .
+
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          # A file, directory or wildcard pattern that describes what to upload
+          path: build/

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
           fi
 
       - name: Build
-        run: make all
+        run: make gh_linux_amd64
 
       - name: Test
         run: go test -v .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,8 @@ strategy:
 
 jobs:
   build:
-    linux_amd64: Build telegram-rss-bot on linux/amd64
+    linux_amd64:
+      name: Build telegram-rss-bot on linux/amd64
       runs-on: ubuntu-latest
       steps:
         - name: Set up Go 1.x
@@ -42,7 +43,8 @@ jobs:
           with:
             # A file, directory or wildcard pattern that describes what to upload
             path: build/
-    windows_amd64: Build telegram-rss-bot on windows/amd64
+    windows_amd64:
+      name: Build telegram-rss-bot on windows/amd64
       runs-on: windows-latest
       steps:
         - name: Set up Go 1.x
@@ -72,7 +74,8 @@ jobs:
           with:
             # A file, directory or wildcard pattern that describes what to upload
             path: build/
-    darwin_amd64: Build telegram-rss-bot on darwin/amd64
+    darwin_amd64:
+      name: Build telegram-rss-bot on darwin/amd64
       runs-on: macos-latest
       steps:
         - name: Set up Go 1.x

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           GOARCH: ${{ env.GOARCH }}
           GOOS: ${{ env.GOOS }}
-        run: go build -o build/telegram-rss-bot-$goos-$goarch
+        run: go build -o build/telegram-rss-bot-$GOARCH-$GOARCH
 
       - name: Test
         run: go test -v .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,97 +11,96 @@ strategy:
     os: [ubuntu-latest, windows-latest, macos-latest]
 
 jobs:
-  build:
-    linux_amd64:
-      name: Build telegram-rss-bot on linux/amd64
-      runs-on: ubuntu-latest
-      steps:
-        - name: Set up Go 1.x
-          uses: actions/setup-go@v2
-          with:
-            go-version: ^1.13
-          id: go
+  linux_amd64:
+    name: Build telegram-rss-bot on linux/amd64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.13
+        id: go
 
-        - name: Check out code into the Go module directory
-          uses: actions/checkout@v2
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
 
-        - name: Get dependencies
-          run: |
-            go get -v -t -d ./...
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
 
-        - name: Build telegram-rss-bot on linux/amd64
-          env:
-            GOOS: linux
-            GOARCH: amd64
-          run: go build -o build/telegram-rss-bot-$GOOS-$GOARCH
+      - name: Build telegram-rss-bot on linux/amd64
+        env:
+          GOOS: linux
+          GOARCH: amd64
+        run: go build -o build/telegram-rss-bot-$GOOS-$GOARCH
 
-        - name: Test
-          run: go test -v .
+      - name: Test
+        run: go test -v .
 
-        - name: Upload a Build Artifact
-          uses: actions/upload-artifact@v2
-          with:
-            # A file, directory or wildcard pattern that describes what to upload
-            path: build/
-    windows_amd64:
-      name: Build telegram-rss-bot on windows/amd64
-      runs-on: windows-latest
-      steps:
-        - name: Set up Go 1.x
-          uses: actions/setup-go@v2
-          with:
-            go-version: ^1.13
-          id: go
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          # A file, directory or wildcard pattern that describes what to upload
+          path: build/
+  windows_amd64:
+    name: Build telegram-rss-bot on windows/amd64
+    runs-on: windows-latest
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.13
+        id: go
 
-        - name: Check out code into the Go module directory
-          uses: actions/checkout@v2
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
 
-        - name: Get dependencies
-          run: |
-            go get -v -t -d ./...
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
 
-        - name: Build telegram-rss-bot on $GOOS/$GOARCH
-          env:
-            GOOS: windows
-            GOARCH: amd64
-          run: go build -o build/telegram-rss-bot-$GOOS-$GOARCH
+      - name: Build telegram-rss-bot on $GOOS/$GOARCH
+        env:
+          GOOS: windows
+          GOARCH: amd64
+        run: go build -o build/telegram-rss-bot-$GOOS-$GOARCH
 
-        - name: Test
-          run: go test -v .
+      - name: Test
+        run: go test -v .
 
-        - name: Upload a Build Artifact
-          uses: actions/upload-artifact@v2
-          with:
-            # A file, directory or wildcard pattern that describes what to upload
-            path: build/
-    darwin_amd64:
-      name: Build telegram-rss-bot on darwin/amd64
-      runs-on: macos-latest
-      steps:
-        - name: Set up Go 1.x
-          uses: actions/setup-go@v2
-          with:
-            go-version: ^1.13
-          id: go
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          # A file, directory or wildcard pattern that describes what to upload
+          path: build/
+  darwin_amd64:
+    name: Build telegram-rss-bot on darwin/amd64
+    runs-on: macos-latest
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.13
+        id: go
 
-        - name: Check out code into the Go module directory
-          uses: actions/checkout@v2
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
 
-        - name: Get dependencies
-          run: |
-            go get -v -t -d ./...
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
 
-        - name: Build telegram-rss-bot on $GOOS/$GOARCH
-          env:
-            GOOS: darwin
-            GOARCH: amd64
-          run: go build -o build/telegram-rss-bot-$GOOS-$GOARCH
+      - name: Build telegram-rss-bot on $GOOS/$GOARCH
+        env:
+          GOOS: darwin
+          GOARCH: amd64
+        run: go build -o build/telegram-rss-bot-$GOOS-$GOARCH
 
-        - name: Test
-          run: go test -v .
+      - name: Test
+        run: go test -v .
 
-        - name: Upload a Build Artifact
-          uses: actions/upload-artifact@v2
-          with:
-            # A file, directory or wildcard pattern that describes what to upload
-            path: build/
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          # A file, directory or wildcard pattern that describes what to upload
+          path: build/

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ strategy:
 
 jobs:
   build:
-    - name: Build telegram-rss-bot on linux/amd64
+    linux_amd64: Build telegram-rss-bot on linux/amd64
       runs-on: ubuntu-latest
       steps:
         - name: Set up Go 1.x
@@ -42,7 +42,7 @@ jobs:
           with:
             # A file, directory or wildcard pattern that describes what to upload
             path: build/
-    - name: Build telegram-rss-bot on windows/amd64
+    windows_amd64: Build telegram-rss-bot on windows/amd64
       runs-on: windows-latest
       steps:
         - name: Set up Go 1.x
@@ -72,7 +72,7 @@ jobs:
           with:
             # A file, directory or wildcard pattern that describes what to upload
             path: build/
-    - name: Build telegram-rss-bot on darwin/amd64
+    darwin_amd64: Build telegram-rss-bot on darwin/amd64
       runs-on: macos-latest
       steps:
         - name: Set up Go 1.x

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,6 +13,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        goos: [linux, windows, darwin]
+        goarch: [amd64]
     steps:
 
       - name: Set up Go 1.x
@@ -30,8 +32,9 @@ jobs:
 
       - name: Build telegram-rss-bot on ${{ matrix.os }}
         env:
-          GOARCH: amd64
-        run: go build
+          GOARCH: ${{ matrix.goarch }}
+          GOOS: ${{ matrix.goos }}
+        run: go build -o build/telegram-rss-bot-$goos-$goarch
 
       - name: Test
         run: go test -v .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,10 +7,12 @@ on:
     branches: [ master ]
 
 jobs:
-
   build:
-    name: Build
-    runs-on: ubuntu-latest
+    name: Build ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
 
       - name: Set up Go 1.x
@@ -30,8 +32,10 @@ jobs:
               dep ensure
           fi
 
-      - name: Build
-        run: make gh_linux_amd64
+      - name: Build telegram-rss-bot on ${{ matrix.os }}
+        env:
+          GOARCH: amd64
+        run: go build
 
       - name: Test
         run: go test -v .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [ master ]
 
-strategy:
-  matrix:
-    os: [ubuntu-latest, windows-latest, macos-latest]
-
 jobs:
   linux_amd64:
     name: Build telegram-rss-bot on linux/amd64

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,10 +27,6 @@ jobs:
       - name: Get dependencies
         run: |
           go get -v -t -d ./...
-          if [ -f Gopkg.toml ]; then
-              curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-              dep ensure
-          fi
 
       - name: Build telegram-rss-bot on ${{ matrix.os }}
         env:

--- a/Makefile
+++ b/Makefile
@@ -5,27 +5,15 @@ all: linux_amd64 darwin_amd64 windows_amd64 checksums
 
 .PHONY: linux_amd64
 linux_amd64:
-	GOOS=linux GOARCH=amd64 go build -v -a -gcflags=-trimpath=$$PWD -asmflags=-trimpath=$$PWD -o build/$(binary_name)-linux-amd64
-
-.PHONY: linux_i386
-linux_i386:
-	GOOS=linux GOARCH=386 go build -v -a -gcflags=-trimpath=$$PWD -asmflags=-trimpath=$$PWD -o build/$(binary_name)-linux-i386
+	CGO_ENABLED=1 CC=/usr/local/bin/x86_64-linux-musl-gcc-9.2.0 GOOS=linux GOARCH=amd64 go build -v -a  -ldflags "-linkmode external -extldflags -static" -gcflags "all=-trimpath=$$PWD;$$HOME" -asmflags "all=-trimpath=$$PWD;$$HOME" -o build/$(binary_name)-linux-amd64
 
 .PHONY: darwin_amd64
 darwin_amd64:
-	GOOS=darwin GOARCH=amd64 go build -v -a -gcflags=-trimpath=$$PWD -asmflags=-trimpath=$$PWD -o build/$(binary_name)-darwin-amd64
-
-.PHONY: darwin_i386
-darwin_i386:
-	GOOS=darwin GOARCH=386 go build -v -a -gcflags=-trimpath=$$PWD -asmflags=-trimpath=$$PWD -o build/$(binary_name)-darwin-i386
+	CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -v -a -gcflags "all=-trimpath=$$PWD;$$HOME" -asmflags "all=-trimpath=$$PWD;$$HOME" -o build/$(binary_name)-darwin-amd64
 
 .PHONY: windows_amd64
 windows_amd64:
-	CC=/usr/local/bin/x86_64-w64-mingw32-gcc GOOS=windows GOARCH=amd64 go build -v -a -gcflags=-trimpath=$$PWD -asmflags=-trimpath=$$PWD -o build/$(binary_name)-windows-amd64.exe
-
-.PHONY: windows_i386
-windows_i386:
-	CC=/usr/local/bin/x86_64-w64-mingw32-gcc GOOS=windows GOARCH=386 go build -v -a -gcflags=-trimpath=$$PWD -asmflags=-trimpath=$$PWD -o build/$(binary_name)-windows-i386.exe
+	CGO_ENABLED=1 CC=/usr/local/bin/x86_64-w64-mingw32-gcc GOOS=windows GOARCH=amd64 go build -v -a -gcflags "all=-trimpath=$$PWD;$$HOME" -asmflags "all=-trimpath=$$PWD;$$HOME" -o build/$(binary_name)-windows-amd64.exe
 
 .PHONY: checksums
 checksums:

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ windows_amd64:
 	CGO_ENABLED=1 CC=/usr/local/bin/x86_64-w64-mingw32-gcc GOOS=windows GOARCH=amd64 go build -v -a -gcflags "all=-trimpath=$$PWD;$$HOME" -asmflags "all=-trimpath=$$PWD;$$HOME" -o build/$(binary_name)-windows-amd64.exe
 
 .PHONY: gh_linux_amd64
-linux_amd64:
+gh_linux_amd64:
 	CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -v -a  -ldflags "-linkmode external -extldflags -static" -gcflags "all=-trimpath=$$PWD;$$HOME" -asmflags "all=-trimpath=$$PWD;$$HOME" -o build/$(binary_name)-linux-amd64
 
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ darwin_amd64:
 windows_amd64:
 	CGO_ENABLED=1 CC=/usr/local/bin/x86_64-w64-mingw32-gcc GOOS=windows GOARCH=amd64 go build -v -a -gcflags "all=-trimpath=$$PWD;$$HOME" -asmflags "all=-trimpath=$$PWD;$$HOME" -o build/$(binary_name)-windows-amd64.exe
 
+.PHONY: gh_linux_amd64
+linux_amd64:
+	CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -v -a  -ldflags "-linkmode external -extldflags -static" -gcflags "all=-trimpath=$$PWD;$$HOME" -asmflags "all=-trimpath=$$PWD;$$HOME" -o build/$(binary_name)-linux-amd64
+
+
 .PHONY: checksums
 checksums:
 	shasum -a 256 build/* > build/checksum.txt

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # telegram-rss-bot
 
+![Build telegram-rss-bot](https://github.com/0x111/telegram-rss-bot/workflows/Build%20telegram-rss-bot/badge.svg)
+
 ## Introduction
 This is an another telegram bot for usage with RSS feeds.
 

--- a/chans/feeds.go
+++ b/chans/feeds.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"github.com/0x111/telegram-rss-bot/feeds"
 	"github.com/0x111/telegram-rss-bot/replies"
+	"github.com/go-telegram-bot-api/telegram-bot-api"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/telegram-bot-api.v4"
 )
 
 // Get Feed Updates from the feeds
@@ -24,9 +24,8 @@ func FeedPosts(Bot *tgbotapi.BotAPI) {
 	feedPosts := feeds.PostFeedUpdatesChan()
 
 	for feedPost := range feedPosts {
-		msg := fmt.Sprintf(`
-	%s - %s
-	`, feedPost.Title, feedPost.Link)
+		link := replies.FilterMessageChars(feedPost.Link)
+		msg := fmt.Sprintf("*%s* \\- [%s](%s)", replies.FilterMessageChars(feedPost.Title), link, link)
 		log.WithFields(log.Fields{"feedPost": feedPost, "chatID": feedPost.ChatID}).Debug("Posting feed update to the Telegram API")
 		err := replies.SimpleMessage(Bot, feedPost.ChatID, 0, msg)
 		if err == nil {

--- a/commands/command.go
+++ b/commands/command.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"github.com/0x111/telegram-rss-bot/feeds"
 	"github.com/0x111/telegram-rss-bot/replies"
+	"github.com/go-telegram-bot-api/telegram-bot-api"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/telegram-bot-api.v4"
 	"strconv"
 	"strings"
 )
@@ -17,7 +17,7 @@ func AddCommand(Bot *tgbotapi.BotAPI, update *tgbotapi.Update) {
 	commandArguments := strings.Split(update.Message.CommandArguments(), " ")
 
 	if len(commandArguments) < 2 {
-		log.Debug("Not enough arguments. We need \"/add name url\"")
+		log.Debug("Not enough arguments\\. We need \"/add name url\"")
 		return
 	}
 
@@ -30,7 +30,7 @@ func AddCommand(Bot *tgbotapi.BotAPI, update *tgbotapi.Update) {
 	txt := ""
 
 	if err == nil {
-		txt = fmt.Sprintf("The feed with the url [%s] was successfully added to this channel!", feedUrl)
+		txt = fmt.Sprintf("The feed with the url [%s] was successfully added to this channel\\!", replies.FilterMessageChars(feedUrl))
 		replies.SimpleMessage(Bot, chatid, update.Message.MessageID, txt)
 	}
 }
@@ -51,7 +51,7 @@ func DeleteCommand(Bot *tgbotapi.BotAPI, update *tgbotapi.Update) {
 	commandArguments := strings.Split(update.Message.CommandArguments(), " ")
 
 	if len(commandArguments) < 1 {
-		panic("Not enough arguments. We need \"/delete id\"")
+		panic("Not enough arguments\\. We need \"/delete id\"")
 	}
 
 	feedid, _ := strconv.Atoi(commandArguments[0])
@@ -60,12 +60,12 @@ func DeleteCommand(Bot *tgbotapi.BotAPI, update *tgbotapi.Update) {
 	err := feeds.DeleteFeedByID(feedid, chatid, userid)
 
 	if err != nil {
-		txt := fmt.Sprintf("There is no feed with the id [%d]!", feedid)
+		txt := fmt.Sprintf("There is no feed with the id [%d]\\!", feedid)
 		replies.SimpleMessage(Bot, chatid, update.Message.MessageID, txt)
 		return
 	}
 
-	txt := fmt.Sprintf("The feed with the id [%d] was successfully deleted!", feedid)
+	txt := fmt.Sprintf("The feed with the id [%d] was successfully deleted\\!", feedid)
 	replies.SimpleMessage(Bot, chatid, update.Message.MessageID, txt)
 }
 
@@ -76,5 +76,5 @@ func HelpCommand(Bot *tgbotapi.BotAPI, update *tgbotapi.Update) {
 /list - With this command you are able to list all the existing feeds with their ID numbers
 /delete %ID - With this command you are able to delete an added feed if you do not need it anymore. The ID parameter is required and you can get it from the /list command 
 	`
-	replies.SimpleMessage(Bot, update.Message.Chat.ID, update.Message.MessageID, txt)
+	replies.SimpleMessage(Bot, update.Message.Chat.ID, update.Message.MessageID, replies.FilterMessageChars(txt))
 }

--- a/feeds/feed.go
+++ b/feeds/feed.go
@@ -7,9 +7,9 @@ import (
 	"github.com/0x111/telegram-rss-bot/db"
 	"github.com/0x111/telegram-rss-bot/models"
 	"github.com/0x111/telegram-rss-bot/replies"
+	"github.com/go-telegram-bot-api/telegram-bot-api"
 	"github.com/mmcdole/gofeed"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/telegram-bot-api.v4"
 	"time"
 )
 
@@ -20,20 +20,20 @@ func AddFeed(Bot *tgbotapi.BotAPI, name string, url string, chatid int64, userid
 
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("There was an error while querying the database!")
-		replies.SimpleMessage(Bot, chatid, 0, "There was an error while adding your feed! Please try again!")
+		replies.SimpleMessage(Bot, chatid, 0, "There was an error while adding your feed\\! Please try again\\!")
 		return err
 	}
 
 	// Check if user is providing a valid feed URL
 	if err := isValidFeed(url); err != nil {
 		log.WithFields(log.Fields{"error": err}).Debug("Invalid feed!")
-		replies.SimpleMessage(Bot, chatid, 0, "The feed you are trying to add is not a valid feed URL!")
+		replies.SimpleMessage(Bot, chatid, 0, "The feed you are trying to add is not a valid feed URL\\!")
 		return errors.New("invalid_feed_url")
 	}
 
 	if exists {
 		log.WithFields(log.Fields{"exists": exists}).Debug("Feed exists!")
-		replies.SimpleMessage(Bot, chatid, 0, "The feed you are trying to add already exists!")
+		replies.SimpleMessage(Bot, chatid, 0, "The feed you are trying to add already exists\\!")
 		return errors.New("feed_exists")
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/PuerkitoBio/goquery v1.5.1 // indirect
+	github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/mmcdole/gofeed v1.0.0-beta2
 	github.com/mmcdole/goxpp v0.0.0-20181012175147-0068e33feabf // indirect

--- a/replies/reply.go
+++ b/replies/reply.go
@@ -2,8 +2,9 @@ package replies
 
 import (
 	"github.com/0x111/telegram-rss-bot/models"
-	"gopkg.in/telegram-bot-api.v4"
+	"github.com/go-telegram-bot-api/telegram-bot-api"
 	"strconv"
+	"strings"
 )
 
 // This function replies the list of feeds to for the command /list
@@ -11,17 +12,17 @@ func ListOfFeeds(botAPI *tgbotapi.BotAPI, feeds *[]models.Feed, chatid int64, me
 	txt := "Here is the list of your added Feeds for this Room: \n"
 
 	if len(*feeds) == 0 {
-		txt += "There is currently no feed added to the list for this Room!\n"
+		txt += "There is currently no feed added to the list for this Room\\!\n"
 	}
 
 	for _, feed := range *feeds {
-		txt += "[#" + strconv.Itoa(feed.ID) + "] *" + feed.Name + "*: " + feed.Url + "\n"
+		txt += "[\\#" + strconv.Itoa(feed.ID) + "] *" + FilterMessageChars(feed.Name) + "*: " + FilterMessageChars(feed.Url) + "\n"
 	}
 
 	msg := tgbotapi.NewMessage(chatid, txt)
 	msg.ReplyToMessageID = messageid
 
-	msg.ParseMode = "markdown"
+	msg.ParseMode = "markdownv2"
 	msg.DisableWebPagePreview = true
 
 	botAPI.Send(msg)
@@ -35,7 +36,7 @@ func SimpleMessage(botAPI *tgbotapi.BotAPI, chatid int64, messageid int, text st
 		msg.ReplyToMessageID = messageid
 	}
 
-	msg.ParseMode = "markdown"
+	msg.ParseMode = "markdownv2"
 	msg.DisableWebPagePreview = false
 
 	_, err := botAPI.Send(msg)
@@ -45,4 +46,29 @@ func SimpleMessage(botAPI *tgbotapi.BotAPI, chatid int64, messageid int, text st
 	}
 
 	return nil
+}
+
+func FilterMessageChars(msg string) string {
+	var markdownEscaper = strings.NewReplacer(
+		"_", "\\_",
+		"*", "\\*",
+		"[", "\\[",
+		"]", "\\]",
+		"(", "\\(",
+		")", "\\)",
+		"~", "\\~",
+		"`", "\\`",
+		">", "\\>",
+		"#", "\\#",
+		"+", "\\+",
+		"-", "\\-",
+		"=", "\\=",
+		"|", "\\|",
+		"{", "\\{",
+		"}", "\\}",
+		".", "\\.",
+		"!", "\\!",
+	)
+
+	return markdownEscaper.Replace(msg)
 }

--- a/telegram-rss-bot.go
+++ b/telegram-rss-bot.go
@@ -6,8 +6,8 @@ import (
 	"github.com/0x111/telegram-rss-bot/conf"
 	"github.com/0x111/telegram-rss-bot/db"
 	"github.com/0x111/telegram-rss-bot/migrations"
+	"github.com/go-telegram-bot-api/telegram-bot-api"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/telegram-bot-api.v4"
 )
 
 func main() {


### PR DESCRIPTION
- Adjust the makefile strip path property, to make it correctly strip the fullpath
- Update telegram bot api to newer version
- Upgrade to markdownv2, escape the escape chars properly so we are able to send formatted message to Telegram API in the correct way
- Remove 32 bit binaries, no support further for those

Closes #1 